### PR TITLE
Fix issue: scan operation issue.

### DIFF
--- a/src/main/java/org/mule/module/hbase/HbaseCloudConnector.java
+++ b/src/main/java/org/mule/module/hbase/HbaseCloudConnector.java
@@ -289,6 +289,11 @@ public class HbaseCloudConnector {
 	 *            required the target table
 	 * @param rowKey
 	 *            the key of the row to update
+	 * @param columnFamilyName
+	 *            limits the scan to a specific column family or null
+	 * @param columnQualifier
+	 *            limits the scan to a specific column or null. Requires a
+	 *            columnFamilyName to be defined.            
 	 * @param maxVersions
 	 *            the maximum number of versions to retrieved
 	 * @param timestamp
@@ -296,8 +301,9 @@ public class HbaseCloudConnector {
 	 * @return the {@link Result}
 	 */
 	@Processor
-	public Result getValues(final String tableName, final String rowKey, @Optional final Integer maxVersions, @Optional final Long timestamp) {
-		return facade.get(tableName, rowKey, maxVersions, timestamp);
+	public Result getValues(final String tableName, final String rowKey,  @Optional final String columnFamilyName,
+			@Optional final String columnQualifier, @Optional final Integer maxVersions, @Optional final Long timestamp) {
+		return facade.get(tableName, rowKey, columnFamilyName, columnQualifier, maxVersions, timestamp);
 	}
 
 	/**

--- a/src/main/java/org/mule/module/hbase/api/HBaseService.java
+++ b/src/main/java/org/mule/module/hbase/api/HBaseService.java
@@ -79,7 +79,7 @@ public interface HBaseService
     void deleteColumn(String tableName, String columnFamilyName);
 
     // ------------ Row Operations
-    Result get(String tableName, String rowKey, Integer maxVersions, Long timestamp);
+    Result get(String tableName, String rowKey,String columnFamilyName, String columnQualifier, Integer maxVersions, Long timestamp);
 
     /**
      * Saves the value at the specified cell (row + family:qualifier + timestamp)

--- a/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
+++ b/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
@@ -867,7 +867,7 @@ public class RPCHBaseService implements HBaseService
         return timestamp != null ? timestamp : HConstants.LATEST_TIMESTAMP;
     }
 
-    private HTableInterface createHTable(String tableName)
+    public HTableInterface createHTable(String tableName)
     {
         return hTableInterfaceFactory.createHTableInterface(configuration, tableName.getBytes(UTF8));
     }

--- a/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
+++ b/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
@@ -944,7 +944,7 @@ public class RPCHBaseService implements HBaseService
         }
         finally
         {
-            if (hTable != null)
+            if (closeHtable && hTable != null)
             {
                 try
                 {

--- a/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
+++ b/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
@@ -422,14 +422,13 @@ public class RPCHBaseService implements HBaseService
 
     // ------------ Row Operations
     /** @see HBaseService#get(String, String, Integer, Long) */
-    public Result get(String tableName, final String rowKey, final Integer maxVersions, final Long timestamp)
-
+    public Result get(String tableName, final String rowKey, final String columnFamilyName, final String columnQualifier, final Integer maxVersions, final Long timestamp)
     {
         return doWithHTable(tableName, new TableCallback<Result>()
         {
             public Result doWithHBaseAdmin(HTableInterface hTable) throws Exception
             {
-                return hTable.get(createGet(rowKey, maxVersions, timestamp));
+                return hTable.get(createGet(rowKey, columnFamilyName, columnQualifier, maxVersions, timestamp));
             }
         });
     }
@@ -463,7 +462,7 @@ public class RPCHBaseService implements HBaseService
     public boolean exists(String tableName, final String row, final Integer maxVersions, final Long timestamp)
 
     {
-        final Result result = get(tableName, row, maxVersions, timestamp);
+        final Result result = get(tableName, row, null, null, maxVersions, timestamp);
         return result != null && !result.isEmpty();
     }
 
@@ -783,9 +782,20 @@ public class RPCHBaseService implements HBaseService
         }
     }
 
-    private Get createGet(String rowKey, Integer maxVersions, Long timestamp)
+    private Get createGet(String rowKey, String columnFamilyName, String columnQualifier, Integer maxVersions, Long timestamp)
     {
         Get get = new Get(rowKey.getBytes(UTF8));
+        if (columnFamilyName != null)
+        {
+            if (columnQualifier != null)
+            {
+            	get.addColumn(columnFamilyName.getBytes(UTF8), columnQualifier.getBytes(UTF8));
+            }
+            else
+            {
+            	get.addFamily(columnFamilyName.getBytes(UTF8));
+            }
+        }
         if (maxVersions != null)
         {
             try

--- a/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
+++ b/src/main/java/org/mule/module/hbase/api/impl/RPCHBaseService.java
@@ -13,6 +13,7 @@ import org.mule.module.hbase.api.ByteArrayConverter;
 import org.mule.module.hbase.api.CompressionType;
 import org.mule.module.hbase.api.HBaseService;
 import org.mule.module.hbase.api.HBaseServiceException;
+import org.mule.transport.NullPayload;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -719,10 +720,12 @@ public class RPCHBaseService implements HBaseService
         {
             public Boolean doWithHBaseAdmin(HTableInterface hTable) throws Exception
             {
-                final Delete delete = createDelete(row, deleteColumnFamilyName, deleteColumnQualifier,
-                    deleteTimestamp, deleteAllVersions, deleteLock);
-                return hTable.checkAndDelete(row.getBytes(UTF8), checkColumnFamilyName.getBytes(UTF8),
-                    checkColumnQualifier.getBytes(UTF8), toByteArray(checkValue), delete);
+            	final Delete delete = createDelete(row, deleteColumnFamilyName, deleteColumnQualifier, deleteTimestamp, deleteAllVersions, deleteLock);
+            	byte[] byteValue = null;
+            	if(checkValue != null && !(checkValue instanceof NullPayload)){
+            		byteValue = toByteArray(checkValue);
+            	}
+            	return hTable.checkAndDelete(row.getBytes(UTF8), checkColumnFamilyName.getBytes(UTF8), checkColumnQualifier.getBytes(UTF8), byteValue, delete);
             }
         });
     }

--- a/src/test/java/org/mule/module/hbase/HbaseTestCase.java
+++ b/src/test/java/org/mule/module/hbase/HbaseTestCase.java
@@ -38,6 +38,8 @@ public class HbaseTestCase
     private static final String SOME_ROW_KEY = "some-row-key";
     private static final String TABLE_NAME = "table-name";
     private static final String COLUMN_NAME = "column-name";
+    private static final String COLUMN_QUALIFIER = "column-qualifier";
+    
     private HbaseCloudConnector connector;
     private HBaseService facade;
     private RowLock lock;
@@ -126,9 +128,9 @@ public class HbaseTestCase
     {
         Result mockResult = mock(Result.class);
         when(mockResult.isEmpty()).thenReturn(false);
-        when(facade.get(eq(TABLE_NAME), eq(SOME_ROW_KEY), anyInt(), anyLong())).thenReturn(mockResult);
+        when(facade.get(eq(TABLE_NAME), eq(SOME_ROW_KEY), eq(COLUMN_QUALIFIER), eq(COLUMN_NAME), anyInt(), anyLong())).thenReturn(mockResult);
 
-        Result result = connector.getValues(TABLE_NAME, SOME_ROW_KEY, 3, 12345L);
+        Result result = connector.getValues(TABLE_NAME, SOME_ROW_KEY, COLUMN_QUALIFIER, COLUMN_NAME, 3, 12345L);
         assertFalse(result.isEmpty());
 
         connector.putValue(TABLE_NAME, SOME_ROW_KEY, COLUMN_NAME, "q", 123L, "value", true, lock);

--- a/src/test/java/org/mule/module/hbase/api/impl/RPCHBaseServiceTestDriver.java
+++ b/src/test/java/org/mule/module/hbase/api/impl/RPCHBaseServiceTestDriver.java
@@ -192,13 +192,13 @@ public class RPCHBaseServiceTestDriver
         rpchBaseService.addColumn(SOME_TABLE_NAME, "family2", null, null, null);
         rpchBaseService.addColumn(SOME_TABLE_NAME, "family3", null, null, null);
 
-        Result ret0 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null);
+        Result ret0 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, null, null);
         assertTrue(ret0.isEmpty());
         assertFalse(rpchBaseService.exists(SOME_TABLE_NAME, SOME_ROW_NAME, null, null));
 
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, SOME_COLUMN_FAMILY_NAME, "q1", null, "value1",
             false, null);
-        Result ret1 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null);
+        Result ret1 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, null, null);
         assertEquals(1, ret1.list().size());
         assertTrue(rpchBaseService.exists(SOME_TABLE_NAME, SOME_ROW_NAME, null, null));
         long ret1timestamp = ret1.list().get(0).getTimestamp();
@@ -211,29 +211,29 @@ public class RPCHBaseServiceTestDriver
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family2", "q4", null, "value4", false, null);
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family2", "q5", null, "value5", false, null);
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family3", "q6", null, "value6", false, null);
-        Result ret2 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null);
+        Result ret2 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, null, null);
         assertEquals(6, ret2.list().size()); // every family
 
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, SOME_COLUMN_FAMILY_NAME, "q2", null, "value2-2",
             false, null);
-        Result ret3 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, 10, null);
+        Result ret3 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, 10, null);
         assertEquals(7, ret3.list().size()); // 6 + 1 old version
 
-        Result ret4 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, 10, ret1timestamp);
+        Result ret4 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, 10, ret1timestamp);
         assertEquals(1, ret4.list().size()); // the first version
 
         rpchBaseService.delete(SOME_TABLE_NAME, SOME_ROW_NAME, SOME_COLUMN_FAMILY_NAME, "q2", null, true,
             null);
-        Result ret5 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, 10, null);
+        Result ret5 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, 10, null);
         assertEquals(5, ret5.list().size()); // q1 + q3 + q4 + q5 + q6
 
         rpchBaseService.delete(SOME_TABLE_NAME, SOME_ROW_NAME, SOME_COLUMN_FAMILY_NAME, null, null, true,
             null);
-        Result ret6 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, 10, null);
+        Result ret6 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, 10, null);
         assertEquals(3, ret6.list().size()); // q4 + q5 + q6
 
         rpchBaseService.delete(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, null, true, null);
-        Result ret7 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, 10, null);
+        Result ret7 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, 10, null);
         assertTrue(ret7.isEmpty());
     }
 
@@ -251,7 +251,7 @@ public class RPCHBaseServiceTestDriver
         assertFalse(ret1.iterator().hasNext());
 
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family1", "q1", null, "value1", false, null);
-        Result row1 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null);
+        Result row1 = rpchBaseService.get(SOME_TABLE_NAME, SOME_ROW_NAME, null, null, null, null);
         final long r1Timestamp = row1.list().get(0).getTimestamp();
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family1", "q2", null, "value2", false, null);
         rpchBaseService.put(SOME_TABLE_NAME, SOME_ROW_NAME, "family1", "q3", null, "value3", false, null);
@@ -261,12 +261,12 @@ public class RPCHBaseServiceTestDriver
 
         rpchBaseService.put(SOME_TABLE_NAME, "r2", "family2", "q1", null, "r2f2q1value", false, null);
         rpchBaseService.put(SOME_TABLE_NAME, "r2", "family2", "q2", null, "r2f2q2value", false, null);
-        Result row2 = rpchBaseService.get(SOME_TABLE_NAME, "r2", null, null);
+        Result row2 = rpchBaseService.get(SOME_TABLE_NAME, "r2", null, null, null, null);
         final long r2Timestamp = row2.list().get(0).getTimestamp();
 
         rpchBaseService.put(SOME_TABLE_NAME, "r3", "family2", "q1", null, "r3f2q1value", false, null);
         rpchBaseService.put(SOME_TABLE_NAME, "r3", "family3", "q2", null, "r3f3q2value", false, null);
-        Result row3 = rpchBaseService.get(SOME_TABLE_NAME, "r3", null, null);
+        Result row3 = rpchBaseService.get(SOME_TABLE_NAME, "r3", null, null, null, null);
         final long r3Timestamp = row3.list().get(0).getTimestamp();
 
         rpchBaseService.put(SOME_TABLE_NAME, "r4", "family3", "q1", null, "r4f3q1value", false, null);
@@ -397,27 +397,27 @@ public class RPCHBaseServiceTestDriver
         assertTrue(rpchBaseService.checkAndPut(SOME_TABLE_NAME, "r1", "f1", "q1", "v1", "f2", "q2", null,
             "v2", false, null));
 
-        Result r2 = rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null);
+        Result r2 = rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null);
         assertEquals("v2", new String(
             r2.getColumnLatest("f2".getBytes(UTF8), "q2".getBytes(UTF8)).getValue(), UTF8));
 
-        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn("f2".getBytes(UTF8),
+        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn("f2".getBytes(UTF8),
             "q2".getBytes(UTF8)));
         assertFalse(rpchBaseService.checkAndDelete(SOME_TABLE_NAME, "r1", "f2", "q1", "v1", "f2", "q2", null,
             true, null));
-        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn("f2".getBytes(UTF8),
+        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn("f2".getBytes(UTF8),
             "q2".getBytes(UTF8)));
         assertFalse(rpchBaseService.checkAndDelete(SOME_TABLE_NAME, "r1", "f1", "q2", "v1", "f2", "q2", null,
             true, null));
-        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn("f2".getBytes(UTF8),
+        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn("f2".getBytes(UTF8),
             "q2".getBytes(UTF8)));
         assertFalse(rpchBaseService.checkAndDelete(SOME_TABLE_NAME, "r1", "f1", "q1", "v2", "f2", "q2", null,
             true, null));
-        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn("f2".getBytes(UTF8),
+        assertTrue(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn("f2".getBytes(UTF8),
             "q2".getBytes(UTF8)));
         assertTrue(rpchBaseService.checkAndDelete(SOME_TABLE_NAME, "r1", "f1", "q1", "v1", "f2", "q2", null,
             true, null));
-        assertFalse(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn(
+        assertFalse(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn(
             "f2".getBytes(UTF8), "q2".getBytes(UTF8)));
     }
 
@@ -441,14 +441,14 @@ public class RPCHBaseServiceTestDriver
         }
         catch (HBaseServiceException e)
         {
-            assertEquals("v1", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null)
+            assertEquals("v1", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null)
                 .getColumnLatest("f1".getBytes(UTF8), "q1".getBytes(UTF8))
                 .getValue(), UTF8));
         }
 
         // put with lock
         rpchBaseService.put(SOME_TABLE_NAME, "r1", "f1", "q1", null, "v3", false, lock);
-        assertEquals("v3", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).getColumnLatest(
+        assertEquals("v3", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).getColumnLatest(
             "f1".getBytes(UTF8), "q1".getBytes(UTF8)).getValue(), UTF8));
 
         // delete locked row
@@ -459,14 +459,14 @@ public class RPCHBaseServiceTestDriver
         }
         catch (HBaseServiceException e)
         {
-            assertEquals("v2", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null)
+            assertEquals("v2", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null)
                 .getColumnLatest("f1".getBytes(UTF8), "q2".getBytes(UTF8))
                 .getValue(), UTF8));
         }
 
         // delete with lock
         rpchBaseService.delete(SOME_TABLE_NAME, "r1", "f1", "q2", null, true, lock);
-        assertFalse(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).containsColumn(
+        assertFalse(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).containsColumn(
             "f1".getBytes(UTF8), "q2".getBytes(UTF8)));
 
         // unlock
@@ -474,7 +474,7 @@ public class RPCHBaseServiceTestDriver
 
         // unlocked put
         rpchBaseService.put(SOME_TABLE_NAME, "r1", "f1", "q1", null, "v2", false, null);
-        assertEquals("v2", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null).getColumnLatest(
+        assertEquals("v2", new String(rpchBaseService.get(SOME_TABLE_NAME, "r1", null, null, null, null).getColumnLatest(
             "f1".getBytes(UTF8), "q1".getBytes(UTF8)).getValue(), UTF8));
     }
 

--- a/src/test/java/org/mule/module/hbase/config/HbaseNamespaceHandlerTestCase.java
+++ b/src/test/java/org/mule/module/hbase/config/HbaseNamespaceHandlerTestCase.java
@@ -52,7 +52,7 @@ public class HbaseNamespaceHandlerTestCase extends FunctionalTestCase
     public void testFlowGet() throws Exception
     {
         final Result mockResult = new Result();
-        when(mockService.get(eq("t1"), eq("r1"), anyInt(), anyLong())).thenReturn(mockResult);
+        when(mockService.get(eq("t1"), eq("r1"), eq("f1"), eq("q1"), anyInt(), anyLong())).thenReturn(mockResult);
 
         final MessageProcessor flow = lookupFlowConstruct("flowGet");
         final MuleEvent event = getTestEvent(null);
@@ -60,7 +60,7 @@ public class HbaseNamespaceHandlerTestCase extends FunctionalTestCase
 
         final Result response = responseEvent.getMessage().getPayload(Result.class);
         assertEquals(mockResult, response);
-        verify(mockService).get(eq("t1"), eq("r1"), anyInt(), anyLong());
+        verify(mockService).get(eq("t1"), eq("r1"), eq("f1"), eq("q1"), anyInt(), anyLong());
     }
 
     public void testFlowPut() throws Exception

--- a/src/test/resources/hbase-namespace-config.xml
+++ b/src/test/resources/hbase-namespace-config.xml
@@ -27,7 +27,7 @@
 	<hbase:config facade-ref="mockFacade" />
 
 	<flow name="flowGet">
-		<hbase:get-values tableName="t1" rowKey="r1" />
+		<hbase:get-values tableName="t1" rowKey="r1" columnFamilyName="f1" columnQualifier="q1" />
 	</flow>
 
 	<flow name="flowPut">


### PR DESCRIPTION
<ul>
<li>
There maybe an issue in the scan operation because the HBaseInterface was closed before retrieving the information. It was reported <a href="https://github.com/mulesoft/hbase-connector/issues/2"> here </a>.

The proposed solution avoid closing the HbaseInterface instance in case the scan method is invoked. That way the data could be retrieved once it is needed. This instance will be closed once there is no more data retrieved in the ScannerAndResults implementation.
</li>
<li>
Extended get-values method making it possible to filter using column name and column family
</li>
<li>
The "check and delete" operation allows passing null as value. According to the <a href="http://hbase.apache.org/0.94/apidocs/org/apache/hadoop/hbase/client/HTableInterface.html#checkAndDelete(byte[], byte[], byte[], byte[], org.apache.hadoop.hbase.client.Delete)">Hbase API </a>, this is allowed in order to check for the lack of a column.
</li>
<li>
Changed the scope of createHTable method in order to make easier to extend the RPCHBaseService.
</li>

</ul>

